### PR TITLE
Improve testing framework

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -7,6 +7,17 @@ RESET=`tput sgr0`
 
 ANY_ERRORS=false
 
+# Make sets this variable when we run it and can influence the test results.
+# Since this script is run through `make`, we need to unset it.
+unset MAKELEVEL
+
+# Get the directory of the current script, in a POSIX compatible way
+# https://stackoverflow.com/a/29835459
+script_directory=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+
+# Set this variable to ensure top level Makefile doesn't affect the results.
+export PROJECT_ROOT="${script_directory}/tests"
+
 describe() {
   printf "\n$BOLD$1$RESET"
 }
@@ -16,10 +27,10 @@ it() {
 }
 
 assert() {
-  if [ $? -eq 0 ]; then
+  if [ $RUN_EXIT -eq 0 ]; then
     printf " ✓"
   else
-    echo "\n    Fail"
+    printf "\n    Fail\n"
     ANY_ERRORS=true
   fi
 }
@@ -28,7 +39,7 @@ assertEqual() {
   if [ "$1" = "$2" ]; then
     printf " ✓"
   else
-    echo "\n   $BOLD$RED Error:$RESET Expected \"$1\" to equal \"$2\""
+    printf "\n   $BOLD$RED Error:$RESET Expected \"$1\" to equal \"$2\"\n"
     ANY_ERRORS=true
   fi
 }

--- a/t
+++ b/t
@@ -21,7 +21,7 @@ VERSION="0.1.0"
 # Global mutable variables.
 QUIET=false
 DRY_RUN=false
-PROJECT_ROOT=""
+PROJECT_ROOT="${PROJECT_ROOT:-}"
 
 has_command() {
   command -v "$1" >/dev/null 2>&1
@@ -226,6 +226,8 @@ detect_and_run() {
 }
 
 set_project_root() {
+  [ -n "${PROJECT_ROOT}" ] && return
+
   # Check if git exists on the system.
   if has_command "git"; then
     # Find the root of the git repository if we are inside one.

--- a/t
+++ b/t
@@ -226,7 +226,9 @@ detect_and_run() {
 }
 
 set_project_root() {
-  [ -n "${PROJECT_ROOT}" ] && return
+  if [ -n "${PROJECT_ROOT}" ]; then
+    return
+  fi
 
   # Check if git exists on the system.
   if has_command "git"; then


### PR DESCRIPTION
List of fixes:
- Unset `MAKELEVEL` since it can alter makefile detection results
- Set `PROJECT_ROOT` to the testing folder to ignore the root `Makefile`
- Fix the `assert` function not using `$?` instead of `$RUN_EXIT`
- Replace `echo` by `printf` to ensure `\n` are rendered properly

I noticed these issues while trying to add tests for my fix to [this issue](https://github.com/paldepind/t-for-test/pull/1#issuecomment-1445399762).
The PR to fix the actual issue depends on this (for the testing part). If you
agree with these changes, I will open my other PR as it is now, otherwise
I'll simply remove the tests from it.